### PR TITLE
remove not needed import

### DIFF
--- a/godot_formatters/godot_gdext_providers.py
+++ b/godot_formatters/godot_gdext_providers.py
@@ -1,6 +1,6 @@
 # fmt: off
 from types import TracebackType
-from typing import Callable, final, Optional, override
+from typing import Callable, final, Optional
 
 from lldb import (SBValue)
 # fmt: on


### PR DESCRIPTION
the import is not used and also makes formatters incompatible with Rider 2025.2